### PR TITLE
Direct download URLs sync with latest

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -12,8 +12,11 @@ import { createApp } from 'vue'
 
 // Plugins
 import { registerPlugins } from '@/plugins'
+import { requestAssets } from "@/plugins/githubfetcher";
 
-const app = createApp(App)
+const app = createApp(App);
+
+app.provide("assets", await requestAssets());
 
 registerPlugins(app)
 

--- a/src/plugins/githubfetcher.ts
+++ b/src/plugins/githubfetcher.ts
@@ -1,0 +1,32 @@
+export interface Assets {
+  url:                  string;
+  id:                   number;
+  node_id:              string;
+  name:                 string;
+  label:                null;
+  uploader:             any;
+  content_type:         string;
+  state:                string;
+  size:                 number;
+  download_count:       number;
+  created_at:           Date;
+  updated_at:           Date;
+  browser_download_url: string;
+}
+
+export async function requestAssets(): Promise<Array<Assets>> {
+  const apiURL = `https://api.github.com/repos/localsend/localsend/releases`;
+  return await fetch(apiURL, {
+    method: "GET",
+    headers: {
+      Accept: "application/vnd.github+json"
+    }
+  }).then((r) => {
+    if (r.ok) return r.json().then(
+      (data) => {
+        //returns the latest assets object from Github
+        return data[0]["assets"]
+      })
+  })
+}
+

--- a/src/views/Download.vue
+++ b/src/views/Download.vue
@@ -73,10 +73,11 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { inject, ref } from 'vue';
 import { mdiDownload, mdiHistory } from '@mdi/js'
 import PageLayout from "@/layouts/PageLayout.vue";
 import {useI18n} from "vue-i18n";
+import {Assets} from "@/plugins/githubfetcher";
 
 const { t } = useI18n()
 
@@ -125,17 +126,22 @@ const nix = {
   ],
 };
 
+const assetsMetadata: Array<Assets> | undefined = inject('assets');
+// Generates a map using file extensions as key
+const assetsMap = new Map(assetsMetadata?.map(obj => [ obj.name.split(".").pop(), obj.browser_download_url ]))
+const fallbackUrl = "https://github.com/localsend/localsend/releases";
+
 const downloadMetadata: Record<OS, Download> = {
   [OS.windows]: {
     stores: [],
     binaries: [
       {
         name: 'MSIX',
-        url: 'https://github.com/localsend/localsend/releases/download/v1.8.0/LocalSend-1.8.0.msix',
+        url: assetsMap.get("msix") ?? fallbackUrl,
       },
       {
         name: t('download.zip'),
-        url: 'https://github.com/localsend/localsend/releases/download/v1.8.0/LocalSend-1.8.0-windows.zip',
+        url: assetsMap.get("zip") ?? fallbackUrl,
       },
     ],
     packageManagers: [
@@ -154,7 +160,7 @@ const downloadMetadata: Record<OS, Download> = {
     binaries: [
       {
         name: 'DMG',
-        url: 'https://github.com/localsend/localsend/releases/download/v1.8.0/LocalSend-1.8.0.dmg',
+        url: assetsMap.get("dmg") ?? fallbackUrl,
       },
     ],
     packageManagers: [
@@ -173,7 +179,7 @@ const downloadMetadata: Record<OS, Download> = {
     binaries: [
       {
         name: 'AppImage',
-        url: 'https://github.com/localsend/localsend/releases/download/v1.8.0/LocalSend-1.8.0.AppImage',
+        url: assetsMap.get("AppImage") ?? fallbackUrl,
       }
     ],
     packageManagers: [
@@ -209,7 +215,7 @@ const downloadMetadata: Record<OS, Download> = {
     binaries: [
       {
         name: 'APK',
-        url: 'https://github.com/localsend/localsend/releases/download/v1.8.0/LocalSend-1.8.0.apk',
+        url: assetsMap.get("apk") ?? fallbackUrl,
       }
     ],
     packageManagers: [],


### PR DESCRIPTION
Github API now in use to get the latest download URLs for the app. 

I'm just not entirely sure if the use of `app.provide` was the most adequate, at least considering I'm not familiar with Vue.