### PR TITLE
Add zh-HK Translations

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -20,7 +20,7 @@
                   :items="localesArray"
                   item-title="label"
                   item-value="value"
-                  style="max-width: 150px">
+                  style="max-width: 200px">
                 </v-select>
               </div>
             </v-col>

--- a/src/locales/zh-HK.json
+++ b/src/locales/zh-HK.json
@@ -1,0 +1,31 @@
+{
+  "home": {
+    "slogan1": "分享檔案畀附近裝置",
+    "slogan2": "免費、開源、跨平台",
+    "download": "下載",
+    "community": "社羣"
+  },
+  "download": {
+    "title": "下載",
+    "appStores": "App Store",
+    "appStoresDescription": "建議多數用户揀選",
+    "binaries": "安裝檔",
+    "binariesDescription": "下載以供離線使用",
+    "packageManagers": "套件管理器",
+    "packageManagersDescription": "以終端命令安裝",
+    "windowsNotice": "由於憑證變更，如果你用緊 v1.7.0 或之前嘅版本，你要解除安裝咗佢先可以裝到 v1.8.0 或之後嘅版本。",
+    "allReleases": "所有版本",
+    "zip": "ZIP（可攜式）"
+  },
+  "community": {
+    "title": "社羣",
+    "getHelp": "尋求幫助",
+    "getHelpDescription": "喺 GitHub 討論區問問題或者揾答案",
+    "getInvolved": "參與其中",
+    "getInvolvedDescription": "聯絡開發人員並且直接為專案作出貢獻",
+    "discord": "Discord",
+    "issues": "GitHub Issues",
+    "pullRequests": "Pull Requests"
+  },
+  "homepageButton": "首頁"
+}

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -6,6 +6,7 @@ import fr from '@/locales/fr.json'
 import ptBR from '@/locales/pt-BR.json'
 import zhCN from '@/locales/zh-CN.json'
 import zhTW from '@/locales/zh-TW.json'
+import zhHK from '@/locales/zh-HK.json'
 
 export const locales: {[key: string]: [string, Record<string, any>]} = {
   'de': ['Deutsch', de],
@@ -14,30 +15,116 @@ export const locales: {[key: string]: [string, Record<string, any>]} = {
   'fr': ['Français', fr],
   'pt-BR': ['Português brasileiro', ptBR],
   'zh-CN': ['简体中文', zhCN],
-  'zh-TW': ['繁體中文', zhTW],
+  'zh-TW': ['繁體中文 – 台灣', zhTW],
+  'zh-HK': ['繁體中文 – 香港', zhHK],
 };
 
-function getBrowserLocale(): string {
-  return navigator.languages !== undefined
-      ? navigator.languages[0]
-      : navigator.language;
+interface LocaleParts {
+  language: string | undefined;
+  extlang: string | undefined;
+  script: string | undefined;
+  region: string | undefined;
 }
 
-function getBestMatchingLocale(browserLocale: string, availableLocales: string[]): string {
-  if (availableLocales.includes(browserLocale)) {
-    return browserLocale;
+const languageToRegionMap: Record<string, string> = {
+  zh: 'CN', // Default to simplified Chinese if only language is given
+}
+const extlangToRegionMap: Record<string, string> = {
+  cmn: 'CN',
+  yue: 'HK',
+}
+const scriptToRegionMap: Record<string, string> = {
+  Hans: 'CN',
+  Hant: 'TW',
+}
+const extlangToLanguageMap: Record<string, string> = {};
+// https://iso639-3.sil.org/code/zho
+for (const extlang of 'zho cdo cjy cmn cpx czh czo gan hak hsn lzh mnp nan wuu yue cnp csp'.split(' ')) {
+  extlangToLanguageMap[extlang] = 'zh';
+}
+const regionToScriptMap: Record<string, string> = {
+  CN: 'Hans',
+  HK: 'Hant',
+  MO: 'Hant',
+  SG: 'Hans',
+  TW: 'Hant',
+}
+const regionToExtlangMap: Record<string, string> = {
+  CN: 'cmn',
+  HK: 'yue',
+  MO: 'yue',
+  SG: 'cmn',
+  TW: 'cmn',
+}
+
+// https://www.rfc-editor.org/rfc/rfc5646
+const localeRegex = /^([a-z]{2,8})(?:-([a-z]{3}(?:-[a-z]{3}){0,2}))?(?:-([a-z]{4}))?(?:-([a-z]{2}|\d{3}))?(?:-[a-z\d]+)*$/;
+// This expands:
+// zh, cmn, zh-Hans and zh-CN to zh-cmn-Hans-CN
+// zh-Hant, zh-TW and zh-Hant-TW to zh-cmn-Hant-TW
+// yue, zh-HK and zh-Hant-HK to zh-yue-Hant-HK
+function parseLocaleParts(locale: string): LocaleParts | undefined {
+  const localeMatch = locale.toLowerCase().match(localeRegex);
+  if (localeMatch) {
+    let [, language, extlang, script, region] = localeMatch as (string | undefined)[];
+    if (language && language.length === 3 && !extlang) {
+      extlang = language;
+      language = extlangToLanguageMap[extlang];
+    }
+    if (script) {
+      script = script[0].toUpperCase() + script.slice(1);
+    }
+    region = region ? region.toUpperCase() : (extlangToRegionMap[extlang!] || scriptToRegionMap[script!] || languageToRegionMap[language!]);
+    if (!extlang) {
+      extlang = regionToExtlangMap[region!];
+    }
+    script = script ? script[0].toUpperCase() + script.slice(1) : regionToScriptMap[region!];
+    return { language, extlang, script, region };
+  }
+}
+
+function getBestMatchingLocale(browserLocales: readonly string[], availableLocales: readonly string[]): string {
+  let parsedAvailableLocales: (LocaleParts | undefined)[];
+  for (const browserLocale of browserLocales) {
+    if (availableLocales.includes(browserLocale)) {
+      return browserLocale;
+    }
+    const locale = parseLocaleParts(browserLocale);
+    if (!locale) {
+      continue;
+    }
+    if (!parsedAvailableLocales!) {
+      parsedAvailableLocales = availableLocales.map(parseLocaleParts);
+    }
+    for (const parts of [['language'], ['extlang', 'script'], ['extlang'], ['script'], ['region']] as (keyof LocaleParts)[][]) {
+      if (!parts.every(part => locale[part])) {
+        continue;
+      }
+      const candidates = parsedAvailableLocales.map(
+        (availableLocale) => availableLocale && parts.every(part => availableLocale[part] === locale[part])
+      );
+      if (candidates.filter(Boolean).length === 1) {
+        return availableLocales[candidates.findIndex(Boolean)];
+      }
+    }
+    for (const part of ['region', 'extlang', 'language'] as const) {
+      if (!locale[part]) {
+        continue;
+      }
+      const index = parsedAvailableLocales.findIndex(
+        (availableLocale) => availableLocale && availableLocale[part] === locale[part]
+      )
+      if (index !== -1) {
+        return availableLocales[index];
+      }
+    }
   }
 
-  const baseLocale = browserLocale.split('-')[0];
-  const matchingLocale = availableLocales.find(
-    (locale) => locale.split('-')[0] === baseLocale
-  );
-
-  return matchingLocale || 'en'; // Fallback to 'en' if no match is found
+  return 'en'; // Fallback to 'en' if no match is found
 }
 
 const availableLocales = Object.keys(locales);
-const bestMatchingLocale = getBestMatchingLocale(getBrowserLocale(), availableLocales);
+const bestMatchingLocale = getBestMatchingLocale(navigator.languages, availableLocales);
 
 export default createI18n({
   legacy: false,


### PR DESCRIPTION
Besides the translations I added some logic to correctly handle Chinese locales. This is related to https://github.com/localsend/localsend/issues/260.

I've try to keep the algorithm neutral instead of hard-coding the algorithm I gave in the comment in the above issue. With the tag expansion logic users don't need to care if the translation file should be named `zh-Hans` or `zh-CN`. Feel free to commit until you feel comfortable with it. I hope this sample helps you deal with the same issue in slang.

I am not familiar to Dart, so I'll leave the implementation job in slang to you.