### PR TITLE
Add flex-wrap to Links for mobile

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,13 +3,26 @@
     <v-main>
       <router-view />
       <v-footer class="pa-0" v-show="showFooter">
-        <v-sheet color="grey-lighten-4" class="pt-8 pb-8 pl-12 pr-2" style="width: 100%">
+        <v-sheet
+          color="grey-lighten-4"
+          class="pt-8 pb-8 pl-12 pr-2"
+          style="width: 100%"
+        >
           <v-row no-gutters>
-
             <!-- License and Copywrite -->
             <v-col cols="12" class="text-center">
-              <p class="text-body-2">Licensed under the <a href="https://opensource.org/licenses/MIT" class="text-decoration-none text-teal" target="_blank">MIT License</a></p>
-              <p class="text-body-2">&copy; 2022 - {{ year }} Tien Do Nam and LocalSend contributors</p>
+              <p class="text-body-2">
+                Licensed under the
+                <a
+                  href="https://opensource.org/licenses/MIT"
+                  class="text-decoration-none text-teal"
+                  target="_blank"
+                  >MIT License</a
+                >
+              </p>
+              <p class="text-body-2">
+                &copy; 2022 - {{ year }} Tien Do Nam and LocalSend contributors
+              </p>
             </v-col>
 
             <!-- Language -->
@@ -20,26 +33,42 @@
                   :items="localesArray"
                   item-title="label"
                   item-value="value"
-                  style="max-width: 200px">
+                  style="max-width: 200px"
+                >
                 </v-select>
               </div>
             </v-col>
 
             <!-- Links -->
-            <v-col cols="12" class="pt-8 d-flex justify-center align-center">
-                <v-btn variant="text" href="https://github.com/localsend/localsend" target="_blank">Github</v-btn>•
-                <v-btn variant="text" href="https://discord.gg/GSRWmQNP87" target="_blank">Discord</v-btn>•
-                <v-btn variant="text" to="/privacy">Privacy</v-btn>•
-                <v-btn variant="text" to="/terms-of-service">Terms</v-btn>•
-                <v-btn variant="text" to="/contact">Contact</v-btn>
+            <v-col
+              cols="12"
+              class="pt-8 d-flex justify-center align-center flex-wrap"
+            >
+              <v-btn
+                variant="text"
+                href="https://github.com/localsend/localsend"
+                target="_blank"
+                >Github</v-btn
+              >•
+              <v-btn
+                variant="text"
+                href="https://discord.gg/GSRWmQNP87"
+                target="_blank"
+                >Discord</v-btn
+              >• <v-btn variant="text" to="/privacy">Privacy</v-btn>•
+              <v-btn variant="text" to="/terms-of-service">Terms</v-btn>•
+              <v-btn variant="text" to="/contact">Contact</v-btn>
             </v-col>
 
             <!-- Disclaimer -->
             <v-col cols="12" class="pt-4 pl-12 pr-12">
               <p class="d-block mt-12 text-grey text-body-2 text-center">
-                This website and LocalSend is not affiliated with, endorsed by, or in any way associated with the brands mentioned on this site.
-                <br>
-                All trademarks, logos, and brand names are the property of their respective owners. We are using these references for informational purposes only.
+                This website and LocalSend is not affiliated with, endorsed by,
+                or in any way associated with the brands mentioned on this site.
+                <br />
+                All trademarks, logos, and brand names are the property of their
+                respective owners. We are using these references for
+                informational purposes only.
               </p>
             </v-col>
           </v-row>
@@ -50,8 +79,8 @@
 </template>
 
 <script setup lang="ts">
-import {onMounted, ref} from "vue";
-import {locales} from "@/plugins/i18n";
+import { onMounted, ref } from "vue";
+import { locales } from "@/plugins/i18n";
 
 const year = new Date().getFullYear();
 


### PR DESCRIPTION
Closes #14 

I added flex-wrap to the Links section to stop them being cut off. 

Potentially could wrap the links in a container and center them like so:

```
<v-container>
      <v-row align="center" justify="center">
        <v-col cols="12" class="text-center">
          <v-btn
            variant="text"
            href="https://github.com/localsend/localsend"
            target="_blank"
          >
            Github
          </v-btn>
          <v-btn
            variant="text"
            href="https://discord.gg/GSRWmQNP87"
            target="_blank"
          >
            Discord
          </v-btn>
          <v-btn variant="text" to="/privacy">Privacy</v-btn>
          <v-btn variant="text" to="/terms-of-service">Terms</v-btn>
          <v-btn variant="text" to="/contact">Contact</v-btn>
        </v-col>
      </v-row>
    </v-container>
```

