### PR TITLE
fix: fix the download commands using Scoop on windows devices

### DIFF
--- a/src/views/Download.vue
+++ b/src/views/Download.vue
@@ -164,7 +164,7 @@ const downloadMetadata = computed<Record<OS, Download>>(() => {
         },
         {
           name: 'Scoop',
-          commands: ['scoop install localsend'],
+          commands: ['scoop bucket add extras; scoop install localsend'],
         },
       ],
     },


### PR DESCRIPTION
The related issue: https://github.com/localsend/localsend/issues/790