### PR TITLE
feat: add hebrew (and rtl support)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "vue": "^3.2.47",
         "vue-i18n": "^9.2.2",
         "vue-router": "^4.0.0",
-        "vuetify": "^3.1.13",
+        "vuetify": "^3.1.15",
         "webfontloader": "^1.0.0"
       },
       "devDependencies": {
@@ -2937,9 +2937,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.1.13",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.1.13.tgz",
-      "integrity": "sha512-mC2UvWqS3Ne/aZ6Q+79kiL36xSe5jGxm0KWWq2e4SRxuqIE14IbyzqfXvU0bEqns0dHU5dOiKCMM9jHZFDLKgQ==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.1.15.tgz",
+      "integrity": "sha512-uxB4UCrP+hFyJaoSsVObAGBRD73qq5ga7HULepzGoMeUWap2H99mcqmMdN/a/Yp4ODK3gT8EcUeph3EgEcsArQ==",
       "engines": {
         "node": "^12.20 || >=14.13"
       },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "vue": "^3.2.47",
     "vue-i18n": "^9.2.2",
     "vue-router": "^4.0.0",
-    "vuetify": "^3.1.13",
+    "vuetify": "^3.1.15",
     "webfontloader": "^1.0.0"
   },
   "devDependencies": {

--- a/src/locales/he.json
+++ b/src/locales/he.json
@@ -1,0 +1,44 @@
+{
+  "home": {
+    "slogan1": "שיתוף קבצים למכשירים בקרבת מקום.",
+    "slogan2": "חינמי, קוד פתוח, וחוצה פלטפורמות.",
+    "download": "הורדה",
+    "community": "קהילה"
+  },
+  "download": {
+    "title": "הורדות",
+    "subTitle": "{os} הורדה עבור",
+    "appStores": "חנויות אפליקציות",
+    "appStoresDescription": "מומלץ עבור רוב המשתמשים.",
+    "binaries": "Binaries",
+    "binariesDescription": "הורדה עבור שימוש לא מקוון.",
+    "packageManagers": "מנהלי חבילות",
+    "packageManagersDescription": "התקנה באמצעות שורת פקודה.",
+    "allReleases": "כל המהדורות",
+    "zip": "ZIP (גרסה ניידת)",
+    "copiedToClipboard": "הועתק ללוח!"
+  },
+  "community": {
+    "title": "קהילה",
+    "getHelp": "קבל עזרה",
+    "getHelpDescription": "שאל או חפש תשובות ב-Github Discussions.",
+    "getInvolved": "תרומה לפרויקט",
+    "getInvolvedDescription": "צור קשר עם המפתחים ותרום ישירות לפרויקט.",
+    "discord": "דיסקורד",
+    "issues": "Issues",
+    "pullRequests": "Pull Requests"
+  },
+  "footer":{
+    "underlicense": "משוחרר תחת",
+    "mitlicense": "רישיון MIT",
+    "andcontributor": "והתורמים של Localsend.",
+    "github": "GitHub",
+    "discord": "דיסקורד",
+    "privacy": "מדיניות פרטיות",
+    "terms": "תנאים",
+    "contact": "צור קשר",
+    "disclaimer-line1": "אתר זה ו-LocalSend אינם מזוהים עם, מאושרים על ידי, או קשורים בכל דרך שהיא למותגים המוזכרים באתר זה.",
+    "disclaimer-line2": "כל הסימנים המסחריים, הסמלים ושמות המותג הינם רכושם של בעליהם. אנו משתמשים בהם למטרות מידע בלבד."
+  },
+  "homepageButton": "דף הבית"
+}

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -16,6 +16,7 @@ import uk from '@/locales/uk.json'
 import zhCN from '@/locales/zh-CN.json'
 import zhTW from '@/locales/zh-TW.json'
 import zhHK from '@/locales/zh-HK.json'
+import he from '@/locales/he.json'
 
 export const locales: { [key: string]: [string, Record<string, any>] } = {
   'cs': ['Čeština', cs],
@@ -24,6 +25,7 @@ export const locales: { [key: string]: [string, Record<string, any>] } = {
   'es': ['Español', es],
   'fr': ['Français', fr],
   'it': ['Italiano', it],
+  'he': ['עברית', he],
   'ja': ['日本語', ja],
   'km': ['ភាសាខ្មែរ', km],
   'ru': ['Русский', ru],

--- a/src/views/Community.vue
+++ b/src/views/Community.vue
@@ -6,7 +6,7 @@
 
         <p>{{ $t('community.getHelpDescription') }}</p>
 
-        <v-btn v-for="(b, index) in helpButtons" v-bind:key="index" variant="tonal" :class="index ? ['ml-4', 'mt-2'] : ['mt-2']" :href="b.url" target="_blank">
+        <v-btn v-for="(b, index) in helpButtons" v-bind:key="index" variant="tonal" :class="index ? ['ms-4', 'mt-2'] : ['mt-2']" :href="b.url" target="_blank">
           {{ b.name }}
         </v-btn>
 
@@ -19,12 +19,12 @@
           &nbsp;{{ $t('community.discord') }}
         </v-btn>
 
-        <v-btn variant="tonal" href="https://github.com/localsend/localsend/issues" class="ml-4 mt-2" target="_blank">
+        <v-btn variant="tonal" href="https://github.com/localsend/localsend/issues" class="ms-4 mt-2" target="_blank">
           <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="currentColor" d="M8 9.5a1.5 1.5 0 1 0 0-3a1.5 1.5 0 0 0 0 3Z"/><path fill="currentColor" d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0a6.5 6.5 0 0 0-13 0Z"/></svg>
           &nbsp;{{ $t('community.issues') }}
         </v-btn>
 
-        <v-btn variant="tonal" href="https://github.com/localsend/localsend/pulls" class="ml-4 mt-2" target="_blank">
+        <v-btn variant="tonal" href="https://github.com/localsend/localsend/pulls" class="ms-4 mt-2" target="_blank">
           <svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 512 512"><path d="M305.8 2.1C314.4 5.9 320 14.5 320 24V64h16c70.7 0 128 57.3 128 128V358.7c28.3 12.3 48 40.5 48 73.3c0 44.2-35.8 80-80 80s-80-35.8-80-80c0-32.8 19.7-61 48-73.3V192c0-35.3-28.7-64-64-64H320v40c0 9.5-5.6 18.1-14.2 21.9s-18.8 2.3-25.8-4.1l-80-72c-5.1-4.6-7.9-11-7.9-17.8s2.9-13.3 7.9-17.8l80-72c7-6.3 17.2-7.9 25.8-4.1zM104 80A24 24 0 1 0 56 80a24 24 0 1 0 48 0zm8 73.3V358.7c28.3 12.3 48 40.5 48 73.3c0 44.2-35.8 80-80 80s-80-35.8-80-80c0-32.8 19.7-61 48-73.3V153.3C19.7 141 0 112.8 0 80C0 35.8 35.8 0 80 0s80 35.8 80 80c0 32.8-19.7 61-48 73.3zM104 432a24 24 0 1 0 -48 0 24 24 0 1 0 48 0zm328 24a24 24 0 1 0 0-48 24 24 0 1 0 0 48z"/></svg>
           &nbsp;{{ $t('community.pullRequests') }}
         </v-btn>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -20,7 +20,7 @@
               <v-btn variant="tonal" size="x-large" class="mt-4" color="primary" :prepend-icon="mdiDownload" to="/download">
                 {{ $t('home.download') }}
               </v-btn>
-              <v-btn variant="tonal" size="x-large" class="ml-4 mt-4" :prepend-icon="mdiAccountMultiple" to="/community">
+              <v-btn variant="tonal" size="x-large" class="ms-4 mt-4" :prepend-icon="mdiAccountMultiple" to="/community">
                 {{ $t('home.community') }}
               </v-btn>
             </div>


### PR DESCRIPTION
I added a Hebrew translation file (I'm a native speaker)
and I also fixed the website layout for RTL (right-to-left languages, like Hebrew and Arabic):
1. I changed it to `ms` (margin-start) instead of `mr` (fixed margin-left)
2. I updated the vuetify dependency version because the current version has a [bug in the language selector](https://github.com/vuetifyjs/vuetify/issues/16885) in RTL, and it was [fixed in v3.1.15](https://github.com/vuetifyjs/vuetify/pull/17099)