### PR TITLE
docs(typo): fix typos in `en.json`

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -21,7 +21,7 @@
   "community": {
     "title": "Community",
     "getHelp": "Get Help",
-    "getHelpDescription": "Ask or look for answers on Github Discussions.",
+    "getHelpDescription": "Ask or look for answers on GitHub Discussions.",
     "getInvolved": "Get Involved",
     "getInvolvedDescription": "Get in contact with the developers and contribute directly to the project.",
     "discord": "Discord",
@@ -31,8 +31,8 @@
   "footer":{
     "underlicense": "Licensed under the",
     "mitlicense": "MIT License",
-    "andcontributor": "and Localsend Contributors.",
-    "github": "Github",
+    "andcontributor": "and LocalSend Contributors.",
+    "github": "GitHub",
     "discord": "Discord",
     "privacy": "Privacy",
     "terms": "Terms",


### PR DESCRIPTION
Typos like un-capitalized charaters were fixed.