### PR TITLE
fix: Chinese translate problem 共享 -> 分享

### DIFF
--- a/lang/zh-CN.json
+++ b/lang/zh-CN.json
@@ -1,17 +1,17 @@
 {
   "home": {
     "seo": {
-      "title": "LocalSend：向附近设备共享文件",
-      "description": "LocalSend是一个免费、开源、跨平台的文件共享工具，允许您将文件共享到附近的设备。"
+      "title": "LocalSend：向附近设备分享文件",
+      "description": "LocalSend是一个免费、开源、跨平台的文件分享工具，允许您将文件分享到附近的设备。"
     },
-    "slogan1": "将文件共享到附近的设备。",
+    "slogan1": "将文件分享到附近的设备。",
     "slogan2": "免费、开源、跨平台。",
     "download": "下载",
     "community": "社区",
     "features": {
       "title": "特点",
       "decentralized": "去中心化",
-      "decentralizedDescription": "无需中央服务器即可共享文件。文件传输完全点对点。",
+      "decentralizedDescription": "无需中央服务器即可分享文件。文件传输完全点对点。",
       "crossPlatform": "跨平台",
       "crossPlatformDescription": "LocalSend可用于Windows、macOS、Linux、Android和iOS。",
       "free": "免费",


### PR DESCRIPTION
## Improve Chinese Translation: Change "共享" to "分享"

**Description:**
This pull request aims to improve the Chinese translation of LocalSend by changing the term "共享" to "分享."

**Rationale:**
In Chinese, the terms "共享" and "分享" both refer to the act of sharing, but they have slightly different connotations and usage contexts:

1. **共享 (Gòngxiǎng):**
   - Typically used in formal or technical contexts.
   - Implies mutual access or usage, often with an emphasis on collective benefit. Commonly used for resources, services, or infrastructure.
   - Example: "共享经济" (sharing economy), "共享单车" (bike-sharing).

2. **分享 (Fēnxiǎng):**
   - More commonly used in everyday language.
   - Focuses on the act of giving and receiving, emphasizing the personal and voluntary aspect of sharing. Often used for content, experiences, or personal items.
   - Example: "分享照片" (sharing photos), "分享经验" (sharing experiences).

Given the context of LocalSend, which is about sending files to nearby devices in a way that users can relate to on a personal level, "分享" is a more appropriate and user-friendly term. It aligns better with the casual and user-centric nature of the application.

**Updated Translation:**
"LocalSend：将文件分享给附近的设备。免费、开源、跨平台。"

Thank you for considering this improvement. I believe this change will enhance the clarity and relatability of the Chinese translation for LocalSend users.