### PR TITLE
The back to home button at the bottom of the download page is obscured.

### DIFF
--- a/pages/download.vue
+++ b/pages/download.vue
@@ -69,7 +69,7 @@
       <!-- Snackbar -->
       <div
           class="absolute bottom-12 transform left-1/2 -translate-x-1/2 bg-teal-950 text-white px-4 py-2 rounded-lg transition-opacity"
-          :class="copyToClipboardSnackbar ? 'opacity-100' : 'opacity-0'">
+          :class="copyToClipboardSnackbar ? 'opacity-100' : 'hidden'">
         {{ t('download.copiedToClipboard') }}
       </div>
     </template>


### PR DESCRIPTION
Fixed the issue that the back to home button at the bottom of the download page was blocked by the copy prompt and it was difficult to click normally.