### PR TITLE
Small change in Greek

### DIFF
--- a/lang/el.json
+++ b/lang/el.json
@@ -15,7 +15,7 @@
       "crossPlatform": "Cross-platform",
       "crossPlatformDescription": "Το LocalSend είναι διαθέσιμο για Windows, macOS, Linux, Android, και iOS.",
       "free": "Δωρεάν",
-      "freeDescription": "Το LocalSend είναι δωρεάν. Όχι διαφημίσεις, όχι παρακολούθηση, όχι κρυφά κόστη.",
+      "freeDescription": "Το LocalSend είναι δωρεάν. Χωρίς διαφημίσεις, χωρίς παρακολούθηση, χωρίς κρυφά κόστη.",
       "openSource": "Ανοικτού κώδικα",
       "openSourceDescription": "Ο κώδικας είναι δημοσίως διαθέσιμος. Ο καθένας μπορεί να συνεισφέρει στο έργο.",
       "secure": "Ασφαλές",


### PR DESCRIPTION
Right now it's directly translated, but in Greek it is better to use "χωρίς" than "όχι" in this particular phrase.