### PR TITLE
Add Swedish (sv) language support

### DIFF
--- a/i18n.config.ts
+++ b/i18n.config.ts
@@ -61,6 +61,7 @@ export const localeMap: { [k: string]: string } = {
   nl: "Nederlands",
   ru: "Русский",
   sr: "Srpski",
+  sv: "Svenska",
   sk: "Slovenčina",
   pl: "Polski",
   "pt-BR": "Português - Brasil",
@@ -75,7 +76,6 @@ export const localeMap: { [k: string]: string } = {
   "zh-CN": "简体中文",
   "zh-TW": "繁體中文 – 台灣",
   "zh-HK": "繁體中文 – 香港",
-  sv: "Svenska",
 };
 
 export default defineI18nConfig(() => ({
@@ -109,6 +109,7 @@ export default defineI18nConfig(() => ({
     "pt-PT": ptPT,
     ru,
     sr,
+    sv,
     sk,
     th,
     ta,
@@ -120,6 +121,5 @@ export default defineI18nConfig(() => ({
     "zh-CN": zhCn,
     "zh-HK": zhHk,
     "zh-TW": zhTw,
-    sv,
   },
 }));

--- a/i18n.config.ts
+++ b/i18n.config.ts
@@ -1,86 +1,87 @@
-import ar from './lang/ar.json'
-import cs from './lang/cs.json'
-import de from './lang/de.json'
-import el from './lang/el.json'
-import en from './lang/en.json'
-import es from './lang/es.json'
-import fa from './lang/fa.json'
-import fil from './lang/fil.json'
-import fr from './lang/fr.json'
-import he from './lang/he.json'
-import hi from './lang/hi.json'
-import id from './lang/id.json'
-import it from './lang/it.json'
-import ja from './lang/ja.json'
-import ka from './lang/ka.json'
-import km from './lang/km.json'
-import ko from './lang/ko.json'
-import mal from './lang/mal-IN.json'
-import mr from './lang/mr.json'
-import nl from './lang/nl.json'
-import pl from './lang/pl.json'
-import ptBr from './lang/pt-BR.json'
-import ptPT from './lang/pt-PT.json'
-import ru from './lang/ru.json'
-import sr from './lang/sr.json'
-import sk from './lang/sk.json'
-import th from './lang/th.json'
-import ta from './lang/ta.json'
-import te from './lang/te.json'
-import tr from './lang/tr.json'
-import uk from './lang/uk.json'
-import vi from './lang/vi.json'
-import zhCn from './lang/zh-CN.json'
-import zhHk from './lang/zh-HK.json'
-import zhTw from './lang/zh-TW.json'
-import bn from './lang/bn.json'
-import ug from './lang/ug.json'
-
+import ar from "./lang/ar.json";
+import cs from "./lang/cs.json";
+import de from "./lang/de.json";
+import el from "./lang/el.json";
+import en from "./lang/en.json";
+import es from "./lang/es.json";
+import fa from "./lang/fa.json";
+import fil from "./lang/fil.json";
+import fr from "./lang/fr.json";
+import he from "./lang/he.json";
+import hi from "./lang/hi.json";
+import id from "./lang/id.json";
+import it from "./lang/it.json";
+import ja from "./lang/ja.json";
+import ka from "./lang/ka.json";
+import km from "./lang/km.json";
+import ko from "./lang/ko.json";
+import mal from "./lang/mal-IN.json";
+import mr from "./lang/mr.json";
+import nl from "./lang/nl.json";
+import pl from "./lang/pl.json";
+import ptBr from "./lang/pt-BR.json";
+import ptPT from "./lang/pt-PT.json";
+import ru from "./lang/ru.json";
+import sr from "./lang/sr.json";
+import sk from "./lang/sk.json";
+import th from "./lang/th.json";
+import ta from "./lang/ta.json";
+import te from "./lang/te.json";
+import tr from "./lang/tr.json";
+import uk from "./lang/uk.json";
+import vi from "./lang/vi.json";
+import zhCn from "./lang/zh-CN.json";
+import zhHk from "./lang/zh-HK.json";
+import zhTw from "./lang/zh-TW.json";
+import bn from "./lang/bn.json";
+import ug from "./lang/ug.json";
+import sv from "./lang/sv.json";
 
 export const localeMap: { [k: string]: string } = {
-  'ar': 'العربية',
-  'bn': 'বাংলা',
-  'cs': 'Čeština',
-  'de': 'Deutsch',
-  'el': 'Ελληνικά',
-  'en': 'English',
-  'es': 'Español',
-  "fa": "فارسی",
-  'fil': 'Filipino',
-  'fr': 'Français',
-  'id': 'Bahasa Indonesia',
-  'it': 'Italiano',
-  'he': 'עברית',
-  'hi': 'हिन्दी',
-  'ja': '日本語',
-  'ka': 'ಕನ್ನಡ',
-  'km': 'ភាសាខ្មែរ',
-  'ko': '한국어',
-  'mal-IN' : 'മലയാളം',
-  'mr': 'मराठी',
-  'nl': 'Nederlands',
-  'ru': 'Русский',
-  'sr': 'Srpski',
-  'sk': 'Slovenčina',
-  'pl': 'Polski',
-  'pt-BR': 'Português - Brasil',
-  'pt-PT': 'Português - Portugal',
-  'th': 'ภาษาไทย',
-  'ta': 'தமிழ்',
-  'te': 'తెలుగు',
-  'tr': 'Türkçe',
-  'uk': 'Українська',
-  'ug': 'ئۇيغۇرچە',
-  'vi': 'Tiếng Việt',
-  'zh-CN': '简体中文',
-  'zh-TW': '繁體中文 – 台灣',
-  'zh-HK': '繁體中文 – 香港',
+  ar: "العربية",
+  bn: "বাংলা",
+  cs: "Čeština",
+  de: "Deutsch",
+  el: "Ελληνικά",
+  en: "English",
+  es: "Español",
+  fa: "فارسی",
+  fil: "Filipino",
+  fr: "Français",
+  id: "Bahasa Indonesia",
+  it: "Italiano",
+  he: "עברית",
+  hi: "हिन्दी",
+  ja: "日本語",
+  ka: "ಕನ್ನಡ",
+  km: "ភាសាខ្មែរ",
+  ko: "한국어",
+  "mal-IN": "മലയാളം",
+  mr: "मराठी",
+  nl: "Nederlands",
+  ru: "Русский",
+  sr: "Srpski",
+  sk: "Slovenčina",
+  pl: "Polski",
+  "pt-BR": "Português - Brasil",
+  "pt-PT": "Português - Portugal",
+  th: "ภาษาไทย",
+  ta: "தமிழ்",
+  te: "తెలుగు",
+  tr: "Türkçe",
+  uk: "Українська",
+  ug: "ئۇيغۇرچە",
+  vi: "Tiếng Việt",
+  "zh-CN": "简体中文",
+  "zh-TW": "繁體中文 – 台灣",
+  "zh-HK": "繁體中文 – 香港",
+  sv: "Svenska",
 };
 
 export default defineI18nConfig(() => ({
   legacy: false,
-  locale: 'en',
-  fallbackLocale: 'en',
+  locale: "en",
+  fallbackLocale: "en",
   messages: {
     ar,
     bn,
@@ -90,7 +91,7 @@ export default defineI18nConfig(() => ({
     en,
     es,
     fa,
-    'fil': fil,
+    fil: fil,
     fr,
     he,
     hi,
@@ -100,12 +101,12 @@ export default defineI18nConfig(() => ({
     ka,
     km,
     ko,
-    'mal-IN' : mal,
+    "mal-IN": mal,
     mr,
     nl,
     pl,
-    'pt-BR': ptBr,
-    'pt-PT': ptPT,
+    "pt-BR": ptBr,
+    "pt-PT": ptPT,
     ru,
     sr,
     sk,
@@ -116,8 +117,9 @@ export default defineI18nConfig(() => ({
     uk,
     ug,
     vi,
-    'zh-CN': zhCn,
-    'zh-HK': zhHk,
-    'zh-TW': zhTw,
-  }
-}))
+    "zh-CN": zhCn,
+    "zh-HK": zhHk,
+    "zh-TW": zhTw,
+    sv,
+  },
+}));

--- a/lang/sv.json
+++ b/lang/sv.json
@@ -1,0 +1,72 @@
+{
+  "home": {
+    "seo": {
+      "title": "LocalSend: Dela filer med närliggande enheter",
+      "description": "LocalSend är ett gratis, öppen källkod, plattformsoberoende fildelningsverktyg som låter dig dela filer med närliggande enheter."
+    },
+    "slogan1": "Dela filer med närliggande enheter.",
+    "slogan2": "Gratis, öppen källkod, plattformsoberoende.",
+    "download": "Ladda ner",
+    "community": "Gemenskap",
+    "features": {
+      "title": "Funktioner",
+      "decentralized": "Decentraliserad",
+      "decentralizedDescription": "Dela filer utan en central server. Filöverföringen är helt peer-to-peer.",
+      "crossPlatform": "Plattformsoberoende",
+      "crossPlatformDescription": "LocalSend är tillgängligt för Windows, macOS, Linux, Android och iOS.",
+      "free": "Gratis",
+      "freeDescription": "LocalSend är gratis att använda. Inga annonser, ingen spårning, inga dolda kostnader.",
+      "openSource": "Öppen källkod",
+      "openSourceDescription": "Källkoden är offentligt tillgänglig. Alla kan bidra till projektet.",
+      "secure": "Säker",
+      "secureDescription": "End-to-end-kryptering säkerställer att endast du och mottagaren kan komma åt dina filer.",
+      "easy": "Lätt att använda",
+      "easyDescription": "Ett enkelt användargränssnitt utan registrering. Andra enheter upptäcks automatiskt."
+    },
+    "mentioned": "Omnämnd över hela världen",
+    "get": "Skaffa LocalSend"
+  },
+  "download": {
+    "seo": {
+      "title": "LocalSend - Nedladdningar",
+      "description": "Ladda ner LocalSend för Windows, macOS, Linux, Android och iOS."
+    },
+    "title": "Nedladdningar",
+    "subTitle": "Nedladdningar för {os}",
+    "appStores": "App-butiker",
+    "appStoresDescription": "Rekommenderas för de flesta användare.",
+    "binaries": "Binärer",
+    "binariesDescription": "Ladda ner för offline-användning.",
+    "packageManagers": "Pakethanterare",
+    "packageManagersDescription": "Installera via terminal.",
+    "allReleases": "Alla versioner",
+    "zip": "ZIP (portabel)",
+    "copiedToClipboard": "Kopierat till urklipp!"
+  },
+  "community": {
+    "seo": {
+      "title": "LocalSend - Gemenskap",
+      "description": "Få hjälp, engagera dig och bidra till LocalSend."
+    },
+    "title": "Gemenskap",
+    "getHelp": "Få hjälp",
+    "getHelpDescription": "Ställ frågor eller sök efter svar på GitHub Discussions.",
+    "getInvolved": "Engagera dig",
+    "getInvolvedDescription": "Kontakta utvecklarna och bidra direkt till projektet.",
+    "discord": "Discord",
+    "issues": "Problem",
+    "pullRequests": "Pull-förfrågningar"
+  },
+  "footer": {
+    "underlicense": "Licensierad under",
+    "license": "Apache 2.0-licensen",
+    "github": "GitHub",
+    "discord": "Discord",
+    "privacy": "Integritet",
+    "terms": "Villkor",
+    "imprint": "Avtryck",
+    "contact": "Kontakt"
+  },
+  "homepageButton": "Hemsida",
+  "improveWebsite": "Förbättra denna webbplats"
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -6,7 +6,9 @@ export default defineNuxtConfig({
     "nuxt-icon",
     "@nuxtjs/sitemap",
   ],
+
   devtools: { enabled: true },
+
   app: {
     pageTransition: {
       name: "page",
@@ -26,9 +28,11 @@ export default defineNuxtConfig({
       ],
     },
   },
+
   site: {
     url: "https://localsend.org",
   },
+
   i18n: {
     baseUrl: "https://localsend.org",
     strategy: "prefix_except_default",
@@ -173,9 +177,9 @@ export default defineNuxtConfig({
         language: "uk-UA",
       },
       {
-        code:"ug",
-        language:"ug-CN",
-        dir: "rtl", 
+        code: "ug",
+        language: "ug-CN",
+        dir: "rtl",
       },
       {
         code: "vi",
@@ -193,11 +197,18 @@ export default defineNuxtConfig({
         code: "zh-TW",
         language: "zh-TW",
       },
+      {
+        code: "sv",
+        language: "sv-SE",
+      },
     ],
   },
+
   nitro: {
     prerender: {
       autoSubfolderIndex: false,
     },
   },
+
+  compatibilityDate: "2024-10-20",
 });


### PR DESCRIPTION
Hey so i found they was no swedish lang and we love this tool so i tought it was best to do!. anyway here is main changes:

1. Added a new file `lang/sv.json` with Swedish translations for the website content.

2. The Swedish translations cover all the main sections of the website, including:
   - Home page
   - Download page
   - Community page
   - Footer

3. The translations are based on the existing English version and follow the structure of other language files.

4. Key changes and considerations:
   - Translated all user-facing strings to Swedish
   - Maintained consistent key names with the English version
   - Adapted phrases to fit Swedish language conventions while preserving the original meaning
   - Ensured proper formatting and punctuation according to Swedish standards.