### PR TITLE
Update French translation

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -10,7 +10,7 @@
     "subTitle": "Téléchargements pour {os}",
     "appStores": "App Stores",
     "appStoresDescription": "Recommandés pour la plupart des utilisateurs.",
-    "binaries": "Fichiers APK",
+    "binaries": "Fichiers Binaires",
     "binariesDescription": "Téléchargements pour une utilisation hors-ligne.",
     "packageManagers": "Gesionnaires de paquets",
     "packageManagersDescription": "Installer via un terminal.",


### PR DESCRIPTION
**Update download/binaries (13:5)**  :Using **'APK'** for **'binaries'** is an incorrect translation because, _first_, it doesn’t actually translate 'binaries,' and _second_, 'Android Package' is specific to Android, yet we still see 'APK files' even when trying to download for Windows.
![image](https://github.com/user-attachments/assets/43026e45-b2aa-4b4c-8fc5-d5bf382414f5)
