### PR TITLE
Add 'Try web' button linking to web app

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -48,6 +48,11 @@
                     {{ t("home.download") }}
                   </AppButton>
                 </NuxtLink>
+                <a href="https://web.localsend.org" target="_blank">
+                  <AppButton icon="material-symbols:language" :dark="true">
+                    {{ t("Try web") }}
+                  </AppButton>
+                </a>
                 <NuxtLink :to="localePath({ path: '/community' })">
                   <AppButton icon="material-symbols:group" :dark="true">
                     {{ t("home.community") }}


### PR DESCRIPTION
Introduces a new button on the home page that links to https://web.localsend.org, allowing users to try the web version of the app.