### PR TITLE
docs(NixOS): replace nix-shell install with programs.localsend + openFirewall for full LAN discoverability

### DIFF
--- a/pages/download.vue
+++ b/pages/download.vue
@@ -193,7 +193,14 @@ const appleStore = `<a href="https://apps.apple.com/us/app/localsend/id166173322
 
 const nix = {
   name: "Nix",
-  commands: ["nix-shell -p localsend", "pkgs.localsend # Config"],
+  commands: [
+    "sudo nano /etc/nixos/configuration.nix",
+    "# Add these lines:",
+    "programs.localsend.enable = true;",
+    "programs.localsend.openFirewall = true;",
+    "# Save and exit the file ,then run:",
+    "sudo nixos-rebuild switch"
+  ],
 };
 
 const assetsMap: Ref<{ [key: string]: string }> = ref({});


### PR DESCRIPTION
### Summary
This updates the NixOS installation instructions for LocalSend to use the official NixOS module (`programs.localsend`) instead of the previous `nix-shell -p localsend` / `pkgs.localsend` method.

### What Changed
**Before:**
```bash
nix-shell -p localsend
pkgs.localsend # Config

**After:**
<img width="1920" height="1080" alt="local-send-bug-fix" src="https://github.com/user-attachments/assets/fd36321f-5a94-4598-97a9-97df5e78ea47" />


References

[Nixpkgs package definition](https://github.com/NixOS/nixpkgs/blob/da4839720b2f7f6e1182aa468e9c819bd5b2792d/pkgs/by-name/lo/localsend/package.nix)

[NixOS module definition](https://github.com/NixOS/nixpkgs/blob/da4839720b2f7f6e1182aa468e9c819bd5b2792d/nixos/modules/programs/localsend.nix)
