### PR TITLE
removed NixOS specific instructions from Darwin/macOS tab

### DIFF
--- a/pages/download.vue
+++ b/pages/download.vue
@@ -262,7 +262,6 @@ const downloadMetadata = computed<Record<OS, Download>>(() => {
           name: "Homebrew",
           commands: ["brew install --cask localsend"],
         },
-        nix,
       ],
     },
     [OS.linux]: {


### PR DESCRIPTION
No module exists for localsend on nix-darwin (the usual configuration module system used for Nix on macOS/darwin) so these instructions don't work as these are NixOS specific. There could be ways to implement a module for nix-darwin to include firewall opening, but the best way for end-users before such module is made would be to use the Homebrew cask using the nix-darwin Homebrew options.