### PR TITLE
fix: correct a grammar in the features(fast) section at the homepage

### DIFF
--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -48,7 +48,7 @@
       "easyDescription": "A simple user interface without registration. Other devices are discovered automatically.",
       "noInternet": "No Internet Required",
       "noInternetDescription": "Works completely offline. Your data never leaves your local network.",
-      "fast": "Blazing Fast",
+      "fast": "Blazingly Fast",
       "fastDescription": "Transfer files at the maximum speed of your WiFi network. No bandwidth limits."
     },
     "press": {


### PR DESCRIPTION
This PR fixes a grammatical error in the “fast” write-up located in the features section on the homepage.