### PR TITLE
fix: corrects the hover color of the "web" button in dark mode

### DIFF
--- a/app/assets/css/style.css
+++ b/app/assets/css/style.css
@@ -213,6 +213,7 @@ h1, h2, h3, h4 {
 
 .btn-secondary:hover {
     background-color: var(--button-bg);
+    color: var(--button-text);
 }
 
 .btn-sm {


### PR DESCRIPTION
I fixed the bug #179 where the text on the “Web” button was no longer visible on hover when the site was in dark mode because the button's text and color were the same. By the way, the new logic behind the change is based on the same pattern as in Light Mode: when hovered over, the “Download” and “Web” buttons have the same colors. 

before : 

https://github.com/user-attachments/assets/66a4b0eb-0900-44de-ad04-e3b1a3b70310

after : 

https://github.com/user-attachments/assets/d1a1fb61-5740-4ec3-af0e-a1d8a6a48686

