### PR TITLE
feat(download): display OS icons in download tab buttons

### DIFF
--- a/app/pages/download.vue
+++ b/app/pages/download.vue
@@ -8,10 +8,11 @@
             <div class="tabs-container">
                 <div class="tabs-header">
                     <button v-for="os in OS" :key="os" 
-                        class="tab-btn" 
+                        class="tab-btn inline-flex items-center justify-center" 
                         :class="{ active: selectedOS === os }"
                         @click="setOS(os)">
-                        {{ os }}
+                        <Icon :name="getOSIcon(os)" class="app-icon mr-2" />
+                        <span>{{ os }}</span>
                     </button>
                 </div>
 


### PR DESCRIPTION
### Description
Enhances the downloads page by displaying operating system icons inside the OS tab buttons (Windows, macOS, Linux, Android, iOS) using the existing `getOSIcon` helper function and `@nuxt/icon`. It also centers and aligns the icons and labels correctly using flex utilities.

### Changes
* Added `<Icon>` element inside the `tab-btn` button loop in `download.vue`.
* Used Tailwind classes `inline-flex items-center justify-center` to align the icons and labels perfectly.

### Screenshots

| Before | After |
| :---: | :---: |
| <img width="450" alt="Before" src="https://github.com/user-attachments/assets/a436c25b-307c-45d4-a417-5d42a8c50662" /> | <img width="450" alt="After" src="https://github.com/user-attachments/assets/e7573bd9-8b72-472b-8947-df3cf6e1e038" /> |
