### PR TITLE
Revamp `zh-HK` translation

### DIFF
--- a/i18n/locales/zh-HK.json
+++ b/i18n/locales/zh-HK.json
@@ -1,181 +1,221 @@
 {
   "home": {
     "seo": {
-      "title": "LocalSend：與附近裝置分享檔案",
-      "description": "LocalSend 是一款免費、開源及跨平台的工具，可讓你與附近的裝置分享檔案。"
+      "title": "LocalSend：分享檔案畀附近裝置",
+      "description": "LocalSend 係免費、開源、跨平台嘅檔案分享工具，畀你同附近裝置互傳檔案。"
     },
     "hero": {
-      "badge": "支援所有主流平台！",
-      "title1": "無需雲端即可分享檔案。",
-      "title2": "快速、私密、離線。",
-      "subtitle": "面向所有人的開源跨平台檔案分享。"
+      "badge": "各大平台都用得！",
+      "title1": "唔使經雲端都 share 到檔案。",
+      "title2": "快、保障私隱、唔使上網。",
+      "subtitle": "人人都用得嘅開源跨平台檔案分享工具。"
     },
-    "slogan1": "與附近裝置分享檔案。",
-    "slogan2": "免費、開源、跨平台。",
     "download": "下載",
-    "web": "網頁",
-    "community": "社群",
+    "web": "網頁版",
+    "search_lang": "搜尋語言……",
+    "lang_notfound": "揾唔到語言",
+    "community": "社羣",
     "stats": {
-      "stars": "GitHub 星標",
+      "stars": "GitHub Stars",
       "downloads": "下載次數",
       "contributors": "貢獻者",
-      "ads": "廣告或追蹤器"
+      "ads": "廣告或者追蹤器"
     },
     "testimonials": {
-      "title": "深受社群喜愛",
-      "description": "加入每日使用 LocalSend 進行檔案傳輸的數千名用戶行列。"
+      "title": "深受社羣歡迎",
+      "description": "同成千上萬用户一樣，每日用 LocalSend 傳檔案。"
     },
     "sponsors": {
-      "title": "贊助商",
-      "description": "LocalSend 能保持免費及開源，全靠合作夥伴和社群的支持。",
-      "infrastructure": "基礎設施夥伴",
-      "becomeSponsor": "成為贊助商",
-      "becomeSponsorDescription": "喜歡 LocalSend？支持開發，讓專案持續成長。"
+      "title": "鳴謝支持",
+      "description": "有賴合作夥伴同社羣支持，LocalSend 先可以一直免費開源。",
+      "infrastructure": "基礎設施合作夥伴",
+      "becomeSponsor": "成為贊助者",
+      "becomeSponsorDescription": "鍾意 LocalSend？支持開發，等個專案可以繼續做落去。"
     },
     "features": {
-      "title": "功能",
-      "description": "提供你在本地網路中快速、安全分享檔案所需的一切。",
-      "decentralized": "去中心化",
-      "decentralizedDescription": "無需中央伺服器，傳輸完全採用 P2P。",
+      "title": "特色",
+      "description": "喺區域網路安全快速 share 檔案，要有嘅功能一應俱全。",
+      "label": "特色",
+      "decentralized": "分散式",
+      "decentralizedDescription": "檔案直接點對點傳送，完全唔使經中央 server。",
       "crossPlatform": "跨平台",
-      "crossPlatformDescription": "LocalSend 支援 Windows、macOS、Linux、Android 與 iOS。",
+      "crossPlatformDescription": "LocalSend 喺 Windows、macOS、Linux、Android 同 iOS 都用得㗎。",
       "free": "免費",
-      "freeDescription": "LocalSend 完全免費──無廣告、無追蹤、無隱藏費用。",
+      "freeDescription": "LocalSend 完全免費，冇廣告、冇追蹤、冇隱藏收費。",
       "openSource": "開源",
-      "openSourceDescription": "程式碼公開，任何人都可以參與貢獻。",
+      "openSourceDescription": "原始碼完全公開，人人都可以幫手改。",
       "secure": "安全",
-      "secureDescription": "端到端加密確保只有你和接收者能存取檔案。",
-      "easy": "易用",
-      "easyDescription": "介面簡單，不需註冊。附近裝置會自動偵測。",
-      "noInternet": "無需上網",
-      "noInternetDescription": "完全離線運作，資料永不離開你的本地網路。",
-      "fast": "高速",
-      "fastDescription": "以 WiFi 網路的最高速度傳輸檔案，無頻寬限制。"
+      "secureDescription": "端對端加密，得你同接收者先開到啲檔案。",
+      "easy": "簡單易用",
+      "easyDescription": "唔使註冊，界面簡單；附近裝置仲會自動出現。",
+      "noInternet": "唔使上網",
+      "noInternetDescription": "完全離線都用得，資料唔會離開你嘅區域網路。",
+      "fast": "快到飛起",
+      "fastDescription": "用盡 Wi‑Fi 網路速度，仲冇頻寬限制。"
     },
     "press": {
       "title": "媒體報導",
-      "description": "看看科技媒體如何評價 LocalSend。",
-      "readArticle": "閱讀文章"
+      "description": "睇下科技媒體點講 LocalSend。",
+      "label": "媒體",
+      "readArticle": "睇全文"
     },
     "faq": {
       "title": "常見問題",
-      "description": "關於 LocalSend 的所有常見問題。",
-      "q1": "真的免費嗎？",
-      "a1": "是的！LocalSend 100% 免費且開源，沒有廣告、沒有追蹤，也沒有隱藏費用。",
-      "q2": "可否透過互聯網運作？",
-      "a2": "不可以。LocalSend 使用你的本地 WiFi 網路，資料不會傳到外部。",
-      "q3": "安全嗎？",
-      "a3": "非常安全。所有傳輸都以 HTTPS 加密，亦可啟用 PIN 驗證。",
-      "q4": "檔案儲存在哪裏？",
-      "a4": "預設儲存在「下載」資料夾，你亦可在設定中更改。",
-      "q5": "支援哪些平台？",
-      "a5": "Windows、macOS、Linux、Android、iOS。",
-      "q6": "需要帳號嗎？",
-      "a6": "不需要。無需註冊或登入──下載即可使用。"
+      "description": "你想知嘅都喺度。",
+      "q1": "真係免費？",
+      "a1": "係，LocalSend 完全免費兼開源，冇廣告、冇追蹤、冇隱藏收費。",
+      "q2": "可唔可以經互聯網傳送？",
+      "a2": "唔可以。LocalSend 只會經你嘅區域 Wi‑Fi 網路傳送，資料唔會走出個網路。",
+      "q3": "安唔安全？",
+      "a3": "安全。所有傳輸都有 HTTPS 加密，仲可以開 PIN 驗證。",
+      "q4": "啲檔案會去咗邊？",
+      "a4": "預設會 save 落裝置嘅「下載」資料夾，亦可以喺設定度改。",
+      "q5": "邊啲平台用得？",
+      "a5": "Windows、macOS、Linux、Android 同 iOS 都用得。",
+      "q6": "要唔要開帳户？",
+      "a6": "唔使。LocalSend 唔使帳户亦唔使登入，裝完就 send 得。"
     },
-    "mentioned": "全球媒體提及",
+    "mentioned": "全球都有報導",
     "get": "下載 LocalSend",
-    "video": "觀看 YouTube 上的 LocalSend 介紹影片"
+    "video": "喺 YouTube 睇 LocalSend 介紹片"
   },
   "cta": {
-    "title": "準備好開始了嗎？",
-    "description": "下載 LocalSend，在你的裝置之間輕鬆分享檔案。",
+    "title": "準備好未？",
+    "description": "即刻下載 LocalSend，輕鬆喺你啲裝置之間互傳檔案。",
     "download": "下載"
   },
   "download": {
     "seo": {
-      "title": "LocalSend – 下載",
-      "description": "下載適用於 Windows、macOS、Linux、Android 和 iOS 的 LocalSend。"
+      "title": "LocalSend – 下載",
+      "description": "下載適用於 Windows、macOS、Linux、Android 同 iOS 嘅 LocalSend。"
     },
     "title": "下載",
-    "subTitle": "{os} 下載",
-    "appStores": "應用商店",
-    "appStoresDescription": "建議大多數用戶使用。",
-    "binaries": "可執行檔",
-    "binariesDescription": "下載以便離線使用。",
+    "subTitle": "{os} 版下載",
+    "appStores": "App Store",
+    "appStoresDescription": "適合大多數用户。",
+    "binaries": "安裝檔",
+    "binariesDescription": "下載後可以離線安裝。",
     "packageManagers": "套件管理器",
-    "packageManagersDescription": "可透過終端機安裝。",
+    "packageManagersDescription": "用終端機安裝。",
     "allReleases": "所有版本",
     "zip": "ZIP",
-    "copiedToClipboard": "已複製到剪貼板！",
-    "noOptions": "沒有 {os} 的額外下載選項。",
-    "scanToInstall": "掃描以安裝",
-    "scanDescription": "使用你的 {os} 裝置掃描此 QR code 開啟下載頁面。",
+    "copiedToClipboard": "已複製到剪貼簿！",
+    "noOptions": "{os} 冇其他下載選項。",
+    "scanToInstall": "掃描嚟安裝",
+    "scanDescription": "用 {os} 裝置掃描呢個 QR code，直接開下載頁。",
     "installer": "安裝程式",
-    "portable": "可攜版本"
+    "portable": "免安裝版"
   },
   "community": {
     "seo": {
-      "title": "LocalSend – 社群",
-      "description": "取得協助、參與討論並為 LocalSend 作出貢獻。"
+      "title": "LocalSend – 社羣",
+      "description": "揾人幫手、參與討論、一齊改進 LocalSend。"
     },
-    "title": "社群",
-    "getHelp": "取得協助",
-    "getHelpDescription": "在 GitHub Discussions 提問或尋找答案。",
-    "getInvolved": "參與貢獻",
-    "getInvolvedDescription": "與開發者交流並直接參與專案。",
+    "title": "社羣",
+    "getHelp": "揾人幫手",
+    "getHelpDescription": "去 GitHub Discussions 問問題或者揾答案。",
+    "getInvolved": "參與其中",
+    "getInvolvedDescription": "同開發者交流，直接落手幫個專案。",
     "discord": "Discord",
-    "discordDescription": "加入我們活躍的伺服器，與開發者聊天並獲得即時支援。",
+    "discordDescription": "加入我哋活躍嘅 server，同開發者傾偈，即時揾人幫手。",
     "reddit": "Reddit",
-    "redditDescription": "參與討論並獲取最新資訊。",
-    "issues": "問題",
-    "issuesDescription": "發現 bug？查看我們的問題追蹤系統。",
+    "redditDescription": "參與討論，緊貼最新公告。",
+    "issues": "GitHub Issues",
+    "issuesDescription": "發現 bug？去 issue tracker 睇下。",
     "pullRequests": "Pull Requests",
-    "prDescription": "想以程式碼作出貢獻？開一個 PR 吧。",
-    "contribute": "貢獻",
-    "contributeDescription": "協助我們讓 LocalSend 更加完善。",
-    "languageSpecific": "加入你所屬語言的討論。"
+    "prDescription": "準備好貢獻程式碼？開個 PR 啦。",
+    "contribute": "幫手",
+    "contributeDescription": "一齊令 LocalSend 更好用。",
+    "languageSpecific": "加入返自己語言嘅討論。"
   },
   "contact": {
     "seo": {
-      "title": "聯絡 – LocalSend",
-      "description": "聯絡開發團隊或社群。"
+      "title": "聯絡方法 – LocalSend",
+      "description": "聯絡團隊或者社羣。"
     },
-    "title": "聯絡我們",
-    "description": "聯絡開發團隊或社群。",
-    "bugReport": "回報錯誤",
-    "bugReportDescription": "發現問題？請在 GitHub Issues 回報，我們會盡快修復。",
+    "title": "聯絡我哋",
+    "description": "聯絡團隊或者社羣。",
+    "bugReport": "回報 bug",
+    "bugReportDescription": "發現問題？去 GitHub Issues 回報，等我哋可以跟進同修正。",
     "openIssues": "開啟 GitHub Issues",
-    "email": "發送電郵",
-    "emailDescription": "適用於一般查詢、合作或私人訊息。"
+    "email": "電郵聯絡",
+    "emailDescription": "一般查詢、合作機會或者私人事宜。"
+  },
+  "donate": {
+    "seo": {
+      "title": "捐款 – LocalSend",
+      "description": "支持 LocalSend 繼續開發。"
+    },
+    "title": "支持 LocalSend",
+    "description": "LocalSend 免費兼開源，你嘅支持可以令開發繼續落去。",
+    "githubSponsors": "GitHub Sponsors",
+    "githubSponsorsDescription": "透過 GitHub Sponsors 單次或者定期贊助 LocalSend。",
+    "becomeSponsor": "成為贊助者",
+    "inApp": "喺 app 入面捐款",
+    "inAppDescription": "你亦可以直接喺手機 app 支持 LocalSend！去設定撳「捐款」就得。",
+    "contribute": "貢獻程式碼",
+    "contributeDescription": "想直接幫手？隨時歡迎喺 GitHub 貢獻程式碼。",
+    "openGithub": "喺 GitHub 開啟"
   },
   "news": {
     "title": "最新消息",
-    "showAll": "查看全部消息"
+    "showAll": "睇晒全部消息"
   },
   "footer": {
-    "description": "無需互聯網，即可與附近裝置分享檔案。開源、跨平台、完全免費。",
-    "underlicense": "在授權下",
-    "license": "Apache License 2.0",
+    "description": "唔使上網，照樣同附近裝置 share 檔案。開源、跨平台、完全免費。",
+    "underlicense": "採用",
+    "license": "Apache 2.0 特許條款",
     "github": "GitHub",
     "discord": "Discord",
     "reddit": "Reddit",
     "merch": "周邊商品",
-    "privacy": "私隱政策",
-    "terms": "使用條款",
-    "imprint": "法律資訊",
-    "contact": "聯絡",
+    "privacy": "私隱權政策",
+    "terms": "服務條款",
+    "imprint": "法律聲明",
+    "contact": "聯絡方法",
+    "donate": "捐款",
     "product": "產品",
-    "community": "社群",
+    "community": "社羣",
     "legal": "法律",
     "download": "下載",
-    "webapp": "網頁應用程式"
+    "webapp": "網頁版",
+    "changelog": "更新記錄",
+    "design_by": "網站設計："
   },
-  "homepageButton": "主頁",
-  "improveWebsite": "改進此網站",
+  "changelog": {
+    "seo": {
+      "title": "LocalSend – 更新記錄",
+      "description": "睇晒 LocalSend 各版本嘅更新、功能同修正。"
+    },
+    "title": "更新記錄",
+    "description": "睇晒各版本嘅更新、功能同修正。",
+    "searchPlaceholder": "搜尋更新……",
+    "all": "全部",
+    "features": "新功能",
+    "fixes": "修正",
+    "i18nFilter": "i18n",
+    "change": "項更新",
+    "changes": "項更新",
+    "upcoming": "就快推出",
+    "noResults": "揾唔到相關更新。",
+    "errorLoading": "載入唔到更新記錄。",
+    "viewOnGithub": "喺 GitHub 睇完整更新記錄"
+  },
+  "homepageButton": "首頁",
+  "improveWebsite": "參與改善呢個網站",
   "navigation": {
     "downloads": "下載",
-    "community": "社群",
-    "contacts": "聯絡"
+    "community": "社羣",
+    "contacts": "聯絡方法"
   },
   "howItWorks": {
-    "title": "運作方式",
-    "description": "無需任何設定。安裝後即可開始分享。",
-    "step1Title": "安裝並開啟",
-    "step1Desc": "在所有裝置上安裝 LocalSend。無需帳號、登入或伺服器。",
-    "step2Title": "選擇檔案",
-    "step2Desc": "選擇相片、影片、文件或文字——支援所有檔案格式。",
-    "step3Title": "點擊即可傳送",
-    "step3Desc": "點選附近的裝置，檔案會立即透過本地網路傳輸。"
+    "title": "點樣用",
+    "description": "唔使設定，裝完就 share 得。",
+    "step1Title": "安裝再開啟",
+    "step1Desc": "所有裝置都裝 LocalSend；唔使帳户、唔使登入、唔使 server。",
+    "step2Title": "揀選檔案",
+    "step2Desc": "相片、影片、文件、文字，乜嘢檔案都得。",
+    "step3Title": "撳一下傳送",
+    "step3Desc": "撳附近嘅裝置，檔案即刻經區域網路傳過去。"
   }
 }


### PR DESCRIPTION
Yes, this is a retranslation. This aligns the register with that currently used by the app. In the vernacular language, it is more likely to attract a greater number of users to the app.
~Like https://github.com/localsend/localsend/pull/3199, I am not going to use Weblate, since the changes are quite substantial.~ I just realised Weblate is not yet used for the website