### PR TITLE
fix: correct Georgian locale metadata

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -208,7 +208,7 @@ export default defineNuxtConfig({
       },
       {
         code: "ka",
-        language: "ka-IN",
+        language: "ka-GE",
         file: "ka.json",
         name: "ქართული",
         englishName: "Georgian",


### PR DESCRIPTION
## Summary

- correct the Georgian locale tag from `ka-IN` to `ka-GE`
- generate accurate HTML, Open Graph, hreflang, and sitemap locale metadata for Georgian pages

## Verification

- `pnpm generate` (1,156 routes generated successfully; existing missing-translation warnings remain)
- a fresh browser with `ka-GE` redirects to `/ka`
- the generated Georgian page uses `lang="ka-GE"` and `og:locale="ka_GE"`
- the generated sitemap uses `hreflang="ka-GE"`